### PR TITLE
fix: pin all dagger.json values

### DIFF
--- a/cool-sdk/dagger.json
+++ b/cool-sdk/dagger.json
@@ -2,5 +2,5 @@
   "name": "cool-sdk",
   "sdk": "go",
   "source": "dagger",
-  "engineVersion": "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+  "engineVersion": "v0.11.9"
 }

--- a/dagger.json
+++ b/dagger.json
@@ -8,5 +8,5 @@
     }
   ],
   "source": "dagger",
-  "engineVersion": "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+  "engineVersion": "v0.11.9"
 }

--- a/dep/dagger.json
+++ b/dep/dagger.json
@@ -8,5 +8,5 @@
     }
   ],
   "source": "dagger",
-  "engineVersion": "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+  "engineVersion": "v0.11.9"
 }

--- a/invalid/bad-dep/dagger.json
+++ b/invalid/bad-dep/dagger.json
@@ -8,5 +8,5 @@
       "source": "../../../foo"
     }
   ],
-  "engineVersion": "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+  "engineVersion": "v0.11.9"
 }

--- a/invalid/bad-source/dagger.json
+++ b/invalid/bad-source/dagger.json
@@ -2,5 +2,5 @@
   "name": "test",
   "sdk": "go",
   "source": "../../../",
-  "engineVersion": "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+  "engineVersion": "v0.11.9"
 }

--- a/py/dagger.json
+++ b/py/dagger.json
@@ -2,5 +2,5 @@
   "name": "test",
   "sdk": "python",
   "source": "dagger",
-  "engineVersion": "v0.11.3"
+  "engineVersion": "v0.11.9"
 }

--- a/subdir/dep2/dagger.json
+++ b/subdir/dep2/dagger.json
@@ -2,5 +2,5 @@
   "name": "dep2",
   "sdk": "go",
   "source": "dagger",
-  "engineVersion": "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+  "engineVersion": "v0.11.9"
 }

--- a/top-level/dagger.json
+++ b/top-level/dagger.json
@@ -8,5 +8,5 @@
     }
   ],
   "source": "dagger",
-  "engineVersion": "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+  "engineVersion": "v0.11.9"
 }

--- a/ts/dagger.json
+++ b/ts/dagger.json
@@ -2,5 +2,5 @@
   "name": "test",
   "sdk": "typescript",
   "source": "dagger",
-  "engineVersion": "v0.11.3"
+  "engineVersion": "v0.11.9"
 }

--- a/various-source-values/samedir/dagger.json
+++ b/various-source-values/samedir/dagger.json
@@ -1,5 +1,5 @@
 {
   "name": "test",
   "sdk": "go",
-  "engineVersion": "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+  "engineVersion": "v0.11.9"
 }

--- a/various-source-values/subdir/dagger.json
+++ b/various-source-values/subdir/dagger.json
@@ -2,5 +2,5 @@
   "name": "test",
   "sdk": "go",
   "source": "some/deep/subdir",
-  "engineVersion": "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+  "engineVersion": "v0.11.9"
 }


### PR DESCRIPTION
Otherwise, they use the latest API and break in annoying ways. Required because of https://github.com/dagger/dagger/pull/7831.

@grouville can we get these mirrored to gitlab/bitbucket once this is merged?