### PR TITLE
Add a golang module to simulate the private dependencies

### DIFF
--- a/privatedeps/README.md
+++ b/privatedeps/README.md
@@ -1,0 +1,1 @@
+This fixture help us to test the private dependency in Dagger integration tests. Please note that this is not a dagger module dependency, instead it is a dependency at golang level.

--- a/privatedeps/go.mod
+++ b/privatedeps/go.mod
@@ -1,0 +1,3 @@
+module github.com/dagger/dagger-test-modules/privatedeps
+
+go 1.23.1

--- a/privatedeps/pkg/cooldep/dep.go
+++ b/privatedeps/pkg/cooldep/dep.go
@@ -1,0 +1,3 @@
+package cooldep
+
+var HowCoolIsThat = "ubercool"


### PR DESCRIPTION
This PR adds a simple golang module to simulate the private dependencies in integration tests.