### PR TITLE
expose moduleTypeDefs to cool-sdk

### DIFF
--- a/cool-sdk/dagger/main.go
+++ b/cool-sdk/dagger/main.go
@@ -1,8 +1,16 @@
 package main
 
-import "main/internal/dagger"
+import (
+	"context"
+
+	"main/internal/dagger"
+)
 
 type CoolSdk struct{}
+
+func (m *CoolSdk) ModuleDefs(ctx context.Context, modSource *dagger.ModuleSource, introspectionJSON *dagger.File) (*dagger.Module, error) {
+	return modSource.WithSDK("go").AsModule(), nil
+}
 
 func (m *CoolSdk) ModuleRuntime(modSource *dagger.ModuleSource, introspectionJson *dagger.File) *dagger.Container {
 	return modSource.WithSDK("go").AsModule().Runtime().WithEnvVariable("COOL", "true")


### PR DESCRIPTION
Exposing the `moduleTypeDefs` function on `cool-sdk`.

Context is: https://github.com/dagger/dagger/pull/10584

In this case, the runtime of the Go SDK has been split in two. The Runtime is only responsible to handle function calls, while ModuleTypeDefs is responsible to get the types exposed by the module. Without this PR, everything is handled by a single entrypoint in the runtime container.

As the Go SDK changed, `modSource.WithSDK("go").AsModule().Runtime()` is producing a container with an entrypoint containing only the function calling, not the exposed types anymore.

This change should be backward compatible: if we are using this SDK with an engine version that doesn't support `ModuleTypeDefs` only `Runtime` will be called, so that's fine. And if `ModuleTypeDefs` needs to be called, then it's working.